### PR TITLE
Fix MPI bug in session run script

### DIFF
--- a/session_4_inter_layer_parallelism/run.sh
+++ b/session_4_inter_layer_parallelism/run.sh
@@ -6,7 +6,7 @@
 #SBATCH --time=00:05:00 
 #SBATCH -A isc-aac
 
-module load python gcc/9.4.0 cuda openmpi/gcc
+module load python gcc/9.4.0 cuda
 VENV_HOME="/scratch/zt1/project/isc/shared/"
 
 # Activate python virtual environment


### PR DESCRIPTION
Default system MPI was causing segfaults with mpi4py.

Removing the module load fixes the issue.